### PR TITLE
Fix placeholder repo URLs and add GitHub link to footer

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -67,7 +67,7 @@ async function main() {
     data: {
       title: "Larry Forum Platform",
       description: "Building the Larry AI Agent Forum - a platform where AI agents collaborate on open source projects.",
-      repoUrl: "https://github.com/example/larry",
+      repoUrl: "https://github.com/BlaineHeffron/Larry",
       status: "OPEN",
       category: "web",
       tags: ["nextjs", "typescript", "prisma", "forum"],
@@ -80,7 +80,7 @@ async function main() {
     data: {
       title: "API Documentation Generator",
       description: "An automated tool that generates comprehensive API docs from OpenAPI specs.",
-      repoUrl: "https://github.com/example/api-docs-gen",
+      repoUrl: "https://github.com/BlaineHeffron/Larry",
       status: "IN_PROGRESS",
       category: "tools",
       tags: ["openapi", "documentation", "automation"],

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,9 +1,38 @@
 export default function Footer() {
   return (
     <footer className="border-t border-[var(--border)] py-8">
-      <p className="text-center text-sm text-[var(--muted-foreground)]">
-        Larry - AI Agent Open Source Forum &copy; {new Date().getFullYear()}
-      </p>
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-between">
+          <p className="text-sm text-[var(--muted-foreground)]">
+            Larry - AI Agent Open Source Forum &copy;{" "}
+            {new Date().getFullYear()}
+          </p>
+          <div className="flex items-center gap-4">
+            <a
+              href="https://github.com/BlaineHeffron/Larry"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="h-4 w-4"
+              >
+                <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
+              </svg>
+              GitHub
+            </a>
+            <a
+              href="/api/v1/openapi.json"
+              className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+            >
+              API Docs
+            </a>
+          </div>
+        </div>
+      </div>
     </footer>
   );
 }


### PR DESCRIPTION
## Summary
- Replace fake `https://github.com/example/...` URLs in seed data with the real Larry repo URL (`https://github.com/BlaineHeffron/Larry`)
- Add GitHub repo link (with icon) and API docs link to the site footer so visiting agents can easily discover the source code

## Test plan
- [ ] Verify the footer renders with GitHub link and API docs link
- [ ] Verify seed data contains correct repo URLs
- [ ] Build succeeds without errors